### PR TITLE
Remove fallback Supabase credentials

### DIFF
--- a/scripts/production-test.js
+++ b/scripts/production-test.js
@@ -4,8 +4,12 @@
  * Tests all critical API endpoints and webhook functionality
  */
 
-const SUPABASE_URL = 'https://jqkkhwoybcenxqpvodev.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Impxa2tod295YmNlbnhxcHZvZGV2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc2MDk4MzksImV4cCI6MjA2MzE4NTgzOX0._CudusgLYlJEv_AkJNGpjavmZNTqxXy4lvAv4laAGd8';
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables');
+}
 
 class ProductionTest {
   constructor() {

--- a/scripts/webhook-auth-test.sh
+++ b/scripts/webhook-auth-test.sh
@@ -4,8 +4,13 @@
 # Webhook Authentication Test Script
 # Tests the Retell webhook authentication with proper headers
 
-SUPABASE_URL="https://jqkkhwoybcenxqpvodev.supabase.co"
-RETELL_SECRET="your_retell_secret_here"  # This should be replaced with actual secret
+SUPABASE_URL="${VITE_SUPABASE_URL:-$SUPABASE_URL}"
+RETELL_SECRET="${RETELL_SECRET}"
+
+if [ -z "$SUPABASE_URL" ] || [ -z "$RETELL_SECRET" ]; then
+  echo "Missing SUPABASE_URL (or VITE_SUPABASE_URL) and/or RETELL_SECRET environment variables" >&2
+  exit 1
+fi
 
 echo "🔐 Testing Retell Webhook Authentication"
 echo "========================================"

--- a/src/components/calls/ProductionCallsTable.tsx
+++ b/src/components/calls/ProductionCallsTable.tsx
@@ -10,6 +10,12 @@ import { Badge } from "@/components/ui/badge";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ?? process.env.VITE_SUPABASE_ANON_KEY;
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY');
+}
+
 export const ProductionCallsTable = () => {
   console.log("🚨 COMPONENTE INICIADO - ProductionCallsTable");
   
@@ -75,10 +81,10 @@ export const ProductionCallsTable = () => {
       // Test 1: Verificar edge function básico
       console.log("🔧 Test 1: Verificando edge function...");
       try {
-        const response = await fetch('https://jqkkhwoybcenxqpvodev.supabase.co/functions/v1/retell-webhook', {
+        const response = await fetch(`${SUPABASE_URL}/functions/v1/retell-webhook`, {
           method: 'GET',
           headers: {
-            'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Impxa2tod295YmNlbnhxcHZvZGV2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc2MDk4MzksImV4cCI6MjA2MzE4NTgzOX0._CudusgLYlJEv_AkJNGpjavmZNTqxXy4lvAv4laAGd8'}`
+            'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
           }
         });
         console.log("🔧 Edge function response:", response.status, response.statusText);
@@ -162,11 +168,11 @@ export const ProductionCallsTable = () => {
           }
         };
         
-        const response = await fetch('https://jqkkhwoybcenxqpvodev.supabase.co/functions/v1/retell-webhook', {
+        const response = await fetch(`${SUPABASE_URL}/functions/v1/retell-webhook`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Impxa2tod295YmNlbnhxcHZvZGV2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc2MDk4MzksImV4cCI6MjA2MzE4NTgzOX0._CudusgLYlJEv_AkJNGpjavmZNTqxXy4lvAv4laAGd8'}`
+            'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
           },
           body: JSON.stringify(testPayload)
         });

--- a/src/components/calls/WebhookDiagnostics.tsx
+++ b/src/components/calls/WebhookDiagnostics.tsx
@@ -7,6 +7,12 @@ import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { RefreshCw, CheckCircle, XCircle, AlertTriangle, Globe, Settings } from "lucide-react";
 
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ?? process.env.VITE_SUPABASE_ANON_KEY;
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY');
+}
+
 interface WebhookDiagnostic {
   name: string;
   status: 'success' | 'error' | 'warning' | 'info';
@@ -69,11 +75,11 @@ export const WebhookDiagnostics = () => {
           }
         };
 
-        const response = await fetch(`https://jqkkhwoybcenxqpvodev.supabase.co/functions/v1/retell-webhook`, {
+        const response = await fetch(`${SUPABASE_URL}/functions/v1/retell-webhook`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`
+            'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
           },
           body: JSON.stringify(testPayload)
         });
@@ -304,8 +310,8 @@ export const WebhookDiagnostics = () => {
         <div className="mt-6 p-4 bg-yellow-50 rounded-lg">
           <h3 className="font-medium text-yellow-900 mb-2">🔍 Debug Info</h3>
           <div className="text-sm text-yellow-800 space-y-1">
-            <p><strong>Expected webhook URL:</strong> https://jqkkhwoybcenxqpvodev.supabase.co/functions/v1/retell-webhook</p>
-            <p><strong>Project ID:</strong> jqkkhwoybcenxqpvodev</p>
+            <p><strong>Expected webhook URL:</strong> {`${SUPABASE_URL}/functions/v1/retell-webhook`}</p>
+            <p><strong>Project ID:</strong> {SUPABASE_URL.replace('https://', '').split('.')[0]}</p>
             <p><strong>Retell needs to send webhooks to this URL for calls to appear</strong></p>
           </div>
         </div>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,25 +1,20 @@
 
 import { createClient } from '@supabase/supabase-js';
 
-// Use environment variables from Vite
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// Read environment variables from Vite (browser) or Node
+const SUPABASE_URL = (import.meta as any)?.env?.VITE_SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = (import.meta as any)?.env?.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY;
 
 // Validate environment variables
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-  console.error(
-    "Missing Supabase environment variables. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your .env file."
+  throw new Error(
+    'Missing Supabase environment variables. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.'
   );
 }
 
-// Create a placeholder client if the environment variables are missing (for development only)
-// This prevents the app from crashing during development if .env is not set up
-const devFallbackUrl = 'https://jqkkhwoybcenxqpvodev.supabase.co';
-const devFallbackKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Impxa2tod295YmNlbnhxcHZvZGV2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc2MDk4MzksImV4cCI6MjA2MzE4NTgzOX0._CudusgLYlJEv_AkJNGpjavmZNTqxXy4lvAv4laAGd8';
-
 export const supabase = createClient(
-  SUPABASE_URL || devFallbackUrl, 
-  SUPABASE_ANON_KEY || devFallbackKey,
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
   {
     auth: {
       persistSession: true,


### PR DESCRIPTION
## Summary
- remove fallback Supabase credentials
- require Supabase environment variables in `ProductionCallsTable` and `WebhookDiagnostics`
- load Supabase config from environment in test scripts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d78f62cf0832f9e3cc42f8dce7185