### PR TITLE
Use env vars for emergency Supabase client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@ VITE_SUPABASE_URL=https://your-project-ref.supabase.co
 # Find this in: Supabase Dashboard > Settings > API > Project API keys > anon public
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.your-anon-key-here
 
+# Emergency Supabase credentials
+VITE_EMERGENCY_SUPABASE_URL=https://your-emergency-project.supabase.co
+VITE_EMERGENCY_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.your-emergency-anon-key
+
 # =============================================================================
 # APPLICATION CONFIGURATION
 # =============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ git clone <YOUR_GIT_URL>
 # Step 2: Navigate to the project directory.
 cd <YOUR_PROJECT_NAME>
 
-# Step 3: Install the necessary dependencies.
+# Step 3: Copy the example environment file and update the values.
+cp .env.example .env
+
+# Step 4: Install the necessary dependencies.
 npm i
 
-# Step 4: Start the development server with auto-reloading and an instant preview.
+# Step 5: Start the development server with auto-reloading and an instant preview.
 npm run dev
 ```
 

--- a/src/integrations/supabase/emergency-client.ts
+++ b/src/integrations/supabase/emergency-client.ts
@@ -1,8 +1,11 @@
 import { createClient } from '@supabase/supabase-js'
 
-// TUS CREDENCIALES REALES - HARDCODEADAS
-const EMERGENCY_SUPABASE_URL = 'https://jqkkhwoybcenxqpvodev.supabase.co'
-const EMERGENCY_SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Impxa2tod295YmNlbnhxcHZvZGV2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc2MDk4MzksImV4cCI6MjA2MzE4NTgzOX0._CudusgLYlJEv_AkJNGpjavmZNTqxXy4lvAv4laAGd8'
+const EMERGENCY_SUPABASE_URL = import.meta.env.VITE_EMERGENCY_SUPABASE_URL
+const EMERGENCY_SUPABASE_ANON_KEY = import.meta.env.VITE_EMERGENCY_SUPABASE_ANON_KEY
+
+if (!EMERGENCY_SUPABASE_URL || !EMERGENCY_SUPABASE_ANON_KEY) {
+  throw new Error('Missing emergency Supabase environment variables')
+}
 
 export const emergencySupabase = createClient(
   EMERGENCY_SUPABASE_URL,


### PR DESCRIPTION
## Summary
- load the emergency Supabase credentials from environment variables
- document creating a `.env` from `.env.example`
- ignore `.env` files

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_684d8e4265d0832fb278a8d8d917b352