### PR TITLE
Fix super admin email case sensitivity

### DIFF
--- a/src/hooks/useEmergencySuperAdmin.ts
+++ b/src/hooks/useEmergencySuperAdmin.ts
@@ -23,7 +23,9 @@ export const useEmergencySuperAdmin = () => {
         setUser(user)
         
         if (user) {
-          const isSuperFromEmail = SUPER_ADMIN_EMAILS.includes(user.email)
+          const isSuperFromEmail = SUPER_ADMIN_EMAILS.includes(
+            user.email?.toLowerCase() ?? ''
+          )
           const isSuperFromUserMetadata = user.user_metadata?.role === 'super_admin'
           const isSuperFromAppMetadata = user.app_metadata?.role === 'super_admin'
           
@@ -52,7 +54,7 @@ export const useEmergencySuperAdmin = () => {
         if (session?.user) {
           setUser(session.user)
           const finalIsSuper = 
-            SUPER_ADMIN_EMAILS.includes(session.user.email) ||
+            SUPER_ADMIN_EMAILS.includes(session.user.email?.toLowerCase() ?? '') ||
             session.user.user_metadata?.role === 'super_admin' ||
             session.user.app_metadata?.role === 'super_admin'
           setIsSuper(finalIsSuper)

--- a/src/hooks/useRole.ts
+++ b/src/hooks/useRole.ts
@@ -29,7 +29,8 @@ export const useRole = () => {
   
   // 🚨 BYPASS TEMPORAL: Verificación específica para emails de super admin
   const SUPER_ADMIN_EMAILS = ['aiagentsdevelopers@gmail.com', 'produpublicol@gmail.com'];
-  const isEmailSuperAdmin = user?.email && SUPER_ADMIN_EMAILS.includes(user.email);
+  const isEmailSuperAdmin =
+    user?.email && SUPER_ADMIN_EMAILS.includes(user.email.toLowerCase());
   
   console.log("🔥 [USE_ROLE] BYPASS DEBUG:");
   console.log("🔥 [USE_ROLE] User email:", user?.email);

--- a/src/hooks/useSuperAdmin.ts
+++ b/src/hooks/useSuperAdmin.ts
@@ -28,7 +28,9 @@ export const useSuperAdmin = () => {
           // 🚨 CORREGIR: Usar user_metadata y app_metadata correctamente
           const isSuperFromUserMetadata = user.user_metadata?.role === 'super_admin'
           const isSuperFromAppMetadata = user.app_metadata?.role === 'super_admin'
-          const isSuperFromEmail = SUPER_ADMIN_EMAILS.includes(user.email)
+          const isSuperFromEmail = SUPER_ADMIN_EMAILS.includes(
+            user.email?.toLowerCase() ?? ''
+          )
           
           const finalIsSuper = isSuperFromUserMetadata || isSuperFromAppMetadata || isSuperFromEmail
           
@@ -63,7 +65,7 @@ export const useSuperAdmin = () => {
           const finalIsSuper = 
             session.user.user_metadata?.role === 'super_admin' ||
             session.user.app_metadata?.role === 'super_admin' ||
-            SUPER_ADMIN_EMAILS.includes(session.user.email)
+            SUPER_ADMIN_EMAILS.includes(session.user.email?.toLowerCase() ?? '')
           setIsSuperAdmin(finalIsSuper)
         } else {
           setUser(null)


### PR DESCRIPTION
## Summary
- ensure case-insensitive email comparison for super admin checks

## Testing
- `bun run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dc112fbdc832f9b5c0b3f0184df00