### PR TITLE
Use RPC for super admin checks

### DIFF
--- a/scripts/curl-test.sh
+++ b/scripts/curl-test.sh
@@ -6,6 +6,7 @@
 
 SUPABASE_URL="https://jqkkhwoybcenxqpvodev.supabase.co"
 ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Impxa2tod295YmNlbnhxcHZvZGV2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc2MDk4MzksImV4cCI6MjA2MzE4NTgzOX0._CudusgLYlJEv_AkJNGpjavmZNTqxXy4lvAv4laAGd8"
+SUPER_ADMIN_UUID=${SUPER_ADMIN_UUID:-"replace-with-super-admin-uuid"}
 
 echo "🔍 Testing Production API Endpoints"
 echo "=================================="
@@ -28,7 +29,7 @@ curl -s -w "\nStatus: %{http_code}\n" \
   -H "Authorization: Bearer $ANON_KEY" \
   -H "Accept: application/json" \
   -H "Content-Type: application/json" \
-  "$SUPABASE_URL/rest/v1/company_members?select=*&user_id=eq.53392e76-008c-4e46-8443-a6ebd6bd4504"
+  "$SUPABASE_URL/rest/v1/company_members?select=*&user_id=eq.$SUPER_ADMIN_UUID"
 
 echo ""
 

--- a/supabase/sql/20250527_update_super_admin.sql
+++ b/supabase/sql/20250527_update_super_admin.sql
@@ -1,0 +1,15 @@
+-- Ensure super admin record exists and RLS policies use dynamic checks
+
+-- Upsert super admin using the current user UUID
+INSERT INTO public.super_admins (id, user_id, email, created_at)
+SELECT gen_random_uuid(), u.id, u.email, now()
+FROM auth.users u
+WHERE u.email = 'aiagentsdevelopers@gmail.com'
+ON CONFLICT (user_id) DO UPDATE SET email = EXCLUDED.email;
+
+-- Replace old UID-based policy with dynamic check
+DROP POLICY IF EXISTS "SuperAdmins_Profiles_Access_UID" ON public.user_profiles;
+CREATE POLICY "SuperAdmins_Profiles_Access"
+  ON public.user_profiles
+  FOR ALL TO authenticated
+  USING (public.is_super_admin() OR id = auth.uid());


### PR DESCRIPTION
## Summary
- add migration to upsert the super admin user and fix profile policy
- determine super admin state via `is_super_admin` RPC
- make curl test use a variable instead of hard coded UUID

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dc5da18d4832fb78e9d70d47a0ba2