### PR TITLE
Add automatic setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This script automatically installs required dependencies when the Codex
+# container starts. It will be executed if placed in the repository root.
+
+# Install Python dependencies if a requirements file exists
+if [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+fi
+
+# Install Node.js dependencies using npm
+if [ -f package.json ]; then
+  npm install
+fi


### PR DESCRIPTION
## Summary
- install dependencies automatically when Codex starts

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684dd8751a3c832f8fd4f54202daab3b