### PR TITLE
feat: externalize emergency supabase credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,13 +9,22 @@
 # =============================================================================
 # SUPABASE CONFIGURATION (Required)
 # =============================================================================
-# Your Supabase project URL - find this in your Supabase dashboard
+# Your primary Supabase project URL - find this in your Supabase dashboard
 # Format: https://[project-ref].supabase.co
 VITE_SUPABASE_URL=https://your-project-ref.supabase.co
 
 # Your Supabase anonymous public key - safe to expose to frontend
 # Find this in: Supabase Dashboard > Settings > API > Project API keys > anon public
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.your-anon-key-here
+
+# =============================================================================
+# EMERGENCY DASHBOARD SUPABASE (Optional)
+# =============================================================================
+# Emergency dashboard Supabase project URL (falls back to VITE_SUPABASE_URL if not set)
+VITE_EMERGENCY_SUPABASE_URL=
+
+# Emergency dashboard Supabase anon key (falls back to VITE_SUPABASE_ANON_KEY if not set)
+VITE_EMERGENCY_SUPABASE_ANON_KEY=
 
 # =============================================================================
 # APPLICATION CONFIGURATION
@@ -56,7 +65,9 @@ VITE_EMAIL_ENABLED=true
 # 3. Set VITE_API_BASE_URL to your deployed application URL
 # 4. Create storage buckets in Supabase Dashboard if using file uploads
 # 5. Configure email templates in Supabase Auth settings if using email features
-# 6. Test all environment variables before deploying to production
+# 6. Configure VITE_EMERGENCY_SUPABASE_URL / VITE_EMERGENCY_SUPABASE_ANON_KEY if the emergency dashboard
+#    should use a dedicated Supabase project (otherwise the primary credentials will be reused)
+# 7. Test all environment variables before deploying to production
 
 # =============================================================================
 # SECURITY NOTES

--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -27,6 +27,18 @@ This guide provides comprehensive instructions for setting up environment variab
 - **Where to find**: Supabase Dashboard > Settings > API > Project API keys > anon public
 - **Security**: Safe to expose in frontend code
 
+#### `VITE_EMERGENCY_SUPABASE_URL`
+- **Description**: Optional Supabase project URL dedicated to emergency dashboards
+- **Format**: `https://[project-ref].supabase.co`
+- **Where to find**: Supabase Dashboard > Settings > API > Project URL
+- **Fallback**: Defaults to `VITE_SUPABASE_URL` when not provided
+
+#### `VITE_EMERGENCY_SUPABASE_ANON_KEY`
+- **Description**: Anonymous key for the emergency Supabase project
+- **Format**: JWT token starting with `eyJ`
+- **Where to find**: Supabase Dashboard > Settings > API > Project API keys > anon public
+- **Fallback**: Defaults to `VITE_SUPABASE_ANON_KEY` when not provided
+
 ### Application Configuration
 
 #### `VITE_API_BASE_URL`
@@ -78,6 +90,9 @@ This guide provides comprehensive instructions for setting up environment variab
 # .env (development)
 VITE_SUPABASE_URL=https://your-dev-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-dev-anon-key
+# Optional: point emergency dashboards to a separate Supabase project
+# VITE_EMERGENCY_SUPABASE_URL=https://your-emergency-dev-project.supabase.co
+# VITE_EMERGENCY_SUPABASE_ANON_KEY=your-emergency-dev-anon-key
 VITE_API_BASE_URL=http://localhost:8080
 VITE_STORAGE_COMPANY_LOGOS_BUCKET=company-logos-dev
 VITE_STORAGE_RECORDINGS_BUCKET=recordings-dev
@@ -92,6 +107,9 @@ VITE_EMAIL_ENABLED=false
 # .env (production)
 VITE_SUPABASE_URL=https://your-prod-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-prod-anon-key
+# Optional: configure dedicated emergency Supabase credentials
+# VITE_EMERGENCY_SUPABASE_URL=https://your-emergency-prod-project.supabase.co
+# VITE_EMERGENCY_SUPABASE_ANON_KEY=your-emergency-prod-anon-key
 VITE_API_BASE_URL=https://your-app.vercel.app
 VITE_STORAGE_COMPANY_LOGOS_BUCKET=company-logos
 VITE_STORAGE_RECORDINGS_BUCKET=recordings

--- a/src/integrations/supabase/emergency-client.ts
+++ b/src/integrations/supabase/emergency-client.ts
@@ -1,12 +1,18 @@
 import { createClient } from '@supabase/supabase-js'
+import { Database } from './types'
 
-// TUS CREDENCIALES REALES - HARDCODEADAS
-const EMERGENCY_SUPABASE_URL = 'https://jqkkhwoybcenxqpvodev.supabase.co'
-const EMERGENCY_SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Impxa2tod295YmNlbnhxcHZvZGV2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc2MDk4MzksImV4cCI6MjA2MzE4NTgzOX0._CudusgLYlJEv_AkJNGpjavmZNTqxXy4lvAv4laAGd8'
+const emergencySupabaseUrl =
+  import.meta.env.VITE_EMERGENCY_SUPABASE_URL || import.meta.env.VITE_SUPABASE_URL
+const emergencySupabaseAnonKey =
+  import.meta.env.VITE_EMERGENCY_SUPABASE_ANON_KEY || import.meta.env.VITE_SUPABASE_ANON_KEY
 
-export const emergencySupabase = createClient(
-  EMERGENCY_SUPABASE_URL,
-  EMERGENCY_SUPABASE_ANON_KEY,
+if (!emergencySupabaseUrl || !emergencySupabaseAnonKey) {
+  throw new Error('Missing emergency Supabase environment variables')
+}
+
+export const emergencySupabase = createClient<Database>(
+  emergencySupabaseUrl,
+  emergencySupabaseAnonKey,
   {
     auth: {
       autoRefreshToken: true,


### PR DESCRIPTION
## Summary
- add dedicated emergency Supabase environment variables to the template and docs
- read the emergency client configuration from environment variables with sensible fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e284c8afd8832f999ed5110400819f